### PR TITLE
Add font preload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,16 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import ReactDOM from 'react-dom';
 import App from './App';
+import DINCondensed from './components/fonts/DIN-Condensed-Bold.ttf';
+
+// Preload the DIN Condensed font so headers render with the correct typeface
+const preloadFont = document.createElement('link');
+preloadFont.rel = 'preload';
+preloadFont.as = 'font';
+preloadFont.href = DINCondensed;
+preloadFont.type = 'font/ttf';
+preloadFont.crossOrigin = 'anonymous';
+document.head.appendChild(preloadFont);
 
 ReactDOM.render(
   <App />,


### PR DESCRIPTION
## Summary
- preload the DIN Condensed font when the app loads

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685edfbd247483278c0b5f4284db4f68