### PR TITLE
Fix parallax jump

### DIFF
--- a/src/pages/Web.js
+++ b/src/pages/Web.js
@@ -204,7 +204,8 @@ useEffect(() => {
     };
 
 
-  window.addEventListener("scroll", handleScroll);
+  window.addEventListener("scroll", handleScroll, { passive: true });
+  handleScroll();
   return () => window.removeEventListener("scroll", handleScroll);
 }, []);
 


### PR DESCRIPTION
## Summary
- call handleScroll on mount so parallax elements don't jump
- make scroll listener passive

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880fa243cb08327b5141822a5fb624d