### PR TITLE
Update contact tile with email link

### DIFF
--- a/src/pages/Web.js
+++ b/src/pages/Web.js
@@ -337,11 +337,23 @@ const imgRefs = useRef([]);
 
         <div className="grid-wrapper">
           <div className="intro-grid">
-            {introTiles.map((tile) => (
-              <div key={tile.id} className={`tile tile--${tile.size}`}>
-                {tile.content}
-              </div>
-            ))}
+            {introTiles.map((tile) => {
+              const classes = `tile tile--${tile.size}$
+{tile.id === 6 ? " contact-tile" : ""}`;
+              const content =
+                tile.id === 6 ? (
+                  <a href="mailto:dylanmax@gmail.com" className="contact-tile__link">
+                    {tile.content}
+                  </a>
+                ) : (
+                  tile.content
+                );
+              return (
+                <div key={tile.id} className={classes}>
+                  {content}
+                </div>
+              );
+            })}
           </div>
         </div>
       </section>

--- a/src/pages/Web.scss
+++ b/src/pages/Web.scss
@@ -122,6 +122,29 @@
   font-size: clamp(4.5vw, 6.2vw, 7.2vw);
 }
 
+/* Contact tile style */
+.contact-tile {
+  position: relative;
+}
+
+.contact-tile__link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+
+.contact-tile::after {
+  content: "";
+  position: absolute;
+  inset: 0.3rem;
+  border: 1px solid black;
+  pointer-events: none;
+}
+
 /* Header */
 .web-exp__header {
   text-align: center;


### PR DESCRIPTION
## Summary
- link the Web page contact tile to `mailto:dylanmax@gmail.com`
- style the contact tile with an inset stroke

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68814097b23883278a97159d05d70daf